### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,7 @@ jobs:
       uses: actions/checkout@v2
     -
       name: Setup Lua
-      uses: leafo/gh-actions-lua@v10
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -28,12 +25,11 @@ jobs:
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-2.0.5"
-          - "luajit-openresty"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
     steps:
     -
       name: Checkout
@@ -42,12 +38,9 @@ jobs:
         submodules: 'true'
     -
       name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v10
+      uses: mah0x211/setup-lua@v1
       with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+        versions: ${{ matrix.lua-version }}
     -
       name: Install Tools
       run: |
@@ -69,7 +62,8 @@ jobs:
         sh ./covgen.sh
     -
       name: Upload c coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage/lcov.info
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/src/device.c
+++ b/src/device.c
@@ -157,7 +157,7 @@ static inline void add_ifa_mtu(lua_State *L, char *ifa_name)
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
 
     if (fd != -1) {
-        struct ifreq ifr;
+        struct ifreq ifr = {0};
 
         strncpy(ifr.ifr_name, ifa_name, IFNAMSIZ - 1);
         if (ioctl(fd, SIOCGIFMTU, &ifr) == 0) {

--- a/src/llsocket.h
+++ b/src/llsocket.h
@@ -51,7 +51,7 @@
 #include <unistd.h>
 // lualib
 #include "config.h"
-#include <lauxhlib.h>
+#include "lauxhlib.h"
 #include <lua_errno.h>
 #include <lua_iovec.h>
 
@@ -247,7 +247,7 @@ static inline lls_addrinfo_t *lls_addrinfo_alloc(lua_State *L,
     memcpy((void *)info->ai.ai_addr, (void *)src->ai_addr, src->ai_addrlen);
     info->ai.ai_canonname  = NULL;
     info->ai_canonname_ref = LUA_NOREF;
-    if (!src->ai_canonname) {
+    if (src->ai_canonname) {
         lua_pushstring(L, src->ai_canonname);
         info->ai.ai_canonname  = (char *)lua_tostring(L, -1);
         info->ai_canonname_ref = lauxh_ref(L);

--- a/test/cmsghdr_test.lua
+++ b/test/cmsghdr_test.lua
@@ -72,14 +72,14 @@ function testcase.rights()
             arg = {
                 true,
             },
-            err = '#1 .+ [(]integer expected, got boolean',
+            err = '#1 .+ [(]int32_t expected, got boolean',
         },
         {
             arg = {
                 1,
                 {},
             },
-            err = '#2 .+ [(]integer expected, got table',
+            err = '#2 .+ [(]int32_t expected, got table',
         },
     }) do
         local err = assert.throws(function()

--- a/test/socket/sockopt_test.lua
+++ b/test/socket/sockopt_test.lua
@@ -191,17 +191,21 @@ end
 
 function testcase.reuseport()
     for _, ai in pairs(addrs) do
-        local s = assert(socket.new(ai:family(), ai:socktype()))
+        -- NOTE: restrict SO_REUSERPORT to inet sockets. so, we should test
+        -- only inet sockets
+        if ai:family() == llsocket.AF_INET then
+            local s = assert(socket.new(ai:family(), ai:socktype()))
 
-        -- test that reuseport socket option can be set
-        local defval = s:reuseport()
-        assert.equal(s:reuseport(true), defval)
-        assert.is_true(s:reuseport())
-        assert.is_true(s:reuseport(false))
-        assert.is_false(s:reuseport())
+            -- test that reuseport socket option can be set
+            local defval = s:reuseport()
+            assert.equal(s:reuseport(true), defval)
+            assert.is_true(s:reuseport())
+            assert.is_true(s:reuseport(false))
+            assert.is_false(s:reuseport())
 
-        s:close()
-        os.remove('./test.sock');
+            s:close()
+            os.remove('./test.sock');
+        end
     end
 end
 


### PR DESCRIPTION
This pull request includes updates to the CI workflow, improvements to error handling and type safety in the C code, and adjustments to tests for better compatibility and clarity. Below is a summary of the most important changes:

### CI Workflow Updates:
* Updated `.github/workflows/test.yml` to replace `leafo/gh-actions-lua` and `leafo/gh-actions-luarocks` with `mah0x211/setup-lua`, simplifying Lua setup and version management. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R14) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L45-R43)
* Modified Lua version matrix to use `:latest` tags for better clarity and maintainability.
* Updated `codecov/codecov-action` to version 4 and added a token for secure uploads.

### C Code Improvements:
* Enhanced type safety in `data_lua` and `rights_lua` functions in `src/cmsghdr.c` by replacing raw integer handling with `int32_t` and adding validation for SCM_RIGHTS data length. [[1]](diffhunk://#diff-f05258a39c4116cabdbead05fdc78b1544add9dfe509b1f94601ea9b50c5103dL35-R59) [[2]](diffhunk://#diff-f05258a39c4116cabdbead05fdc78b1544add9dfe509b1f94601ea9b50c5103dL112-R128)
* Fixed potential uninitialized memory issue in `add_ifa_mtu` by initializing the `struct ifreq` with `{0}`.
* Corrected logic in `lls_addrinfo_alloc` to handle `ai_canonname` properly in `src/llsocket.h`.

### Test Adjustments:
* Updated error messages in `test/cmsghdr_test.lua` to reflect the change from `integer` to `int32_t` for argument type validation.
* Restricted SO_REUSEPORT tests to IPv4 sockets for compatibility, adding a note for clarity in `test/socket/sockopt_test.lua`. [[1]](diffhunk://#diff-6b12dcd5396e1e5a3600987713bd2c7aa190b2c24931d03c813332370535531fR194-R196) [[2]](diffhunk://#diff-6b12dcd5396e1e5a3600987713bd2c7aa190b2c24931d03c813332370535531fR210)

### Minor Fixes:
* Fixed an include directive in `src/llsocket.h` to use double quotes for consistency with other headers.